### PR TITLE
Keep encryption key in b64 format

### DIFF
--- a/mythic_container/LoggingBase.py
+++ b/mythic_container/LoggingBase.py
@@ -92,8 +92,8 @@ class NewCallbackLoggingData:
         self.Locked = locked
         self.OperationID = operation_id
         self.CryptoType = crypto_type
-        self.DecKey = base64.b64decode(dec_key) if dec_key is not None else None
-        self.EncKey = base64.b64decode(enc_key) if enc_key is not None else None
+        self.DecKey = dec_key if dec_key is not None else None
+        self.EncKey = enc_key if enc_key is not None else None
         self.OS = os
         self.Architecture = architecture
         self.Domain = domain


### PR DESCRIPTION
When we want to use the `LoggingBase` component with a custom payload. 
The Logger could not sucessfully logged new callbacks because : 

- the constructor of `NewCallbackLoggingData` decode our encryption key from B64.
- then the `LoggingMessage` class constructor instantiate its attribute Data with the NewCallbackLoggingData object containing our payload data
- when the logger attempt to write the `LoggingMessage` object, the `__str__` function failed due to the execption raised by `json.dumps(self.to_json(), sort_keys=True, indent=2)` because the value of the keys `enc_key`and `dec_key` have a bytes type which is not a correct type when we want to call json.dumps.

Therefore a solution is to keep the crypto keys in base64 format.

![image](https://github.com/MythicMeta/MythicContainerPyPi/assets/18192211/18ec6c3b-e71e-4bef-a601-a28f1dfedfeb)
![image](https://github.com/MythicMeta/MythicContainerPyPi/assets/18192211/8d5d7973-2e9e-4759-88e2-29b15e592842)
![image](https://github.com/MythicMeta/MythicContainerPyPi/assets/18192211/cfe2a57f-a700-4c34-a7b4-6da5e7eeff50)

