### PR TITLE
Update MythicRPC.py

### DIFF
--- a/mythic_container/MythicRPC.py
+++ b/mythic_container/MythicRPC.py
@@ -198,10 +198,16 @@ async def legacyAddCommandsToCallback(x: dict) -> RPCResponse:
 
 
 async def legacyGetCallbackInfo(x: dict) -> RPCResponse:
+    cb_id = x.pop("callback_id")
+    
     resp = await SendMythicRPCCallbackSearch(MythicRPCCallbackSearchMessage(
-        AgentCallbackID=x.pop("callback_id"),
-        SearchCallbackID=x.pop("callback_id")
+        AgentCallbackID=cb_id,
+        SearchCallbackID=cb_id
     ))
+    # resp = await SendMythicRPCCallbackSearch(MythicRPCCallbackSearchMessage(
+    #     AgentCallbackID=x.pop("callback_id"),
+    #     SearchCallbackID=x.pop("callback_id")
+    # ))
     return RPCResponse({
         "status": "success" if resp.Success else "error",
         "error": resp.Error,


### PR DESCRIPTION
The callback_id cannot be popped twice. Otherwise, there should be just one CallbackID either AgentCallbackID or SearchCallbackID.

Please have unit tests for MythicRPC and add parameter explanation for parameters, which is not convenient to use.

