### PR TITLE
Add custom JSON encoder for bytes

### DIFF
--- a/mythic_container/MythicCommandBase.py
+++ b/mythic_container/MythicCommandBase.py
@@ -1754,7 +1754,7 @@ class PTTaskMessageAllData:
     Note: Lowercase names are used in the __init__ function to auto-populate from JSON, but attributes are upper case.
 
     Attributes:
-        Task (PTTaskMessageTaskData): The information about this task and its callback, payload, build params, etc
+        Task (PTTaskMessageTaskData): The information about this task
         Callback (PTTaskMessageCallbackData): The information about this task's callback
         Payload (PTTaskMessagePayloadData): The information about this task's associated payload
         Commands (list[str]): The names of all the commands currently loaded into this callback

--- a/mythic_container/MythicCommandBase.py
+++ b/mythic_container/MythicCommandBase.py
@@ -12,6 +12,19 @@ from mythic_container.MythicGoRPC.send_mythic_rpc_payload_create_from_scratch im
     MythicRPCPayloadConfigurationBuildParameter, MythicRPCPayloadConfigurationC2Profile
 
 
+class BytesEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            # Create a more readable representation of bytes
+            result = "[bytes]"
+            for byte in obj:
+                if 32 <= byte <= 126:  # Printable ASCII range
+                    result += chr(byte)
+                else:
+                    result += f"\\x{byte:02x}"
+            return result
+        return super().default(obj)
+
 class SupportedOS:
     """Supported Operating System
 
@@ -1741,7 +1754,7 @@ class PTTaskMessageAllData:
     Note: Lowercase names are used in the __init__ function to auto-populate from JSON, but attributes are upper case.
 
     Attributes:
-        Task (PTTaskMessageTaskData): The information about this task
+        Task (PTTaskMessageTaskData): The information about this task and its callback, payload, build params, etc
         Callback (PTTaskMessageCallbackData): The information about this task's callback
         Payload (PTTaskMessagePayloadData): The information about this task's associated payload
         Commands (list[str]): The names of all the commands currently loaded into this callback
@@ -1808,7 +1821,7 @@ class PTTaskMessageAllData:
                          raw_command_line=self.Task.OriginalParams, )
 
     def __str__(self):
-        return json.dumps(self.to_json(), sort_keys=True, indent=2)
+        return json.dumps(self.to_json(), sort_keys=True, indent=2, cls=BytesEncoder)
 
 
 class PTCallbacksToCheck:


### PR DESCRIPTION
Fixes #16 

### Enhancements to JSON serialization:

* Introduced a new `BytesEncoder` class to provide a more readable representation of bytes when serializing to JSON. This encoder converts byte data into a human-readable format, making it easier to understand byte content in JSON outputs.
* Updated the `__str__` method in the `PTTaskMessageAllData` class to use the new `BytesEncoder` for JSON serialization. This ensures that any byte data within the task message is serialized using the improved representation provided by `BytesEncoder`.