### PR TITLE
Added support for OperationID fields on FileSearch and FileUpdate

### DIFF
--- a/mythic_container/MythicGoRPC/send_mythic_rpc_file_search.py
+++ b/mythic_container/MythicGoRPC/send_mythic_rpc_file_search.py
@@ -17,6 +17,7 @@ class MythicRPCFileSearchMessage:
                  IsPayload: bool = False,
                  AgentFileID: str = None,
                  Comment: str = "",
+                 OperationID: int = None,
                  **kwargs):
         self.TaskID = TaskID
         self.CallbackID = CallbackID
@@ -28,6 +29,7 @@ class MythicRPCFileSearchMessage:
         self.Comment = Comment
         self.IsPayload = IsPayload
         self.AgentFileID = AgentFileID
+        self.OperationID = OperationID
         for k, v in kwargs.items():
             logger.info(f"Unknown kwarg {k} - {v}")
 
@@ -42,7 +44,8 @@ class MythicRPCFileSearchMessage:
             "is_download_from_agent": self.IsDownloadFromAgent,
             "is_payload": self.IsPayload,
             "file_id": self.AgentFileID,
-            "comment": self.Comment
+            "comment": self.Comment,
+            "operation_id": self.OperationID
         }
 
 

--- a/mythic_container/MythicGoRPC/send_mythic_rpc_file_update.py
+++ b/mythic_container/MythicGoRPC/send_mythic_rpc_file_update.py
@@ -14,7 +14,6 @@ class MythicRPCFileUpdateMessage:
                  ReplaceContents: bytes = None,
                  Delete: bool = None,
                  DeleteAfterFetch: bool = None,
-                 OperationID: int = None,
                  **kwargs):
         self.AgentFileID = AgentFileID
         self.Filename = Filename
@@ -23,7 +22,6 @@ class MythicRPCFileUpdateMessage:
         self.ReplaceContents = ReplaceContents
         self.Delete = Delete
         self.DeleteAfterFetch = DeleteAfterFetch
-        self.OperationID = OperationID
         for k, v in kwargs.items():
             logger.info(f"Unknown kwarg {k} - {v}")
 
@@ -35,7 +33,6 @@ class MythicRPCFileUpdateMessage:
             "append_contents": self.AppendContents,
             "delete": self.Delete,
             "delete_after_fetch": self.DeleteAfterFetch,
-            "operation_id": self.OperationID
         }
 
 

--- a/mythic_container/MythicGoRPC/send_mythic_rpc_file_update.py
+++ b/mythic_container/MythicGoRPC/send_mythic_rpc_file_update.py
@@ -14,6 +14,7 @@ class MythicRPCFileUpdateMessage:
                  ReplaceContents: bytes = None,
                  Delete: bool = None,
                  DeleteAfterFetch: bool = None,
+                 OperationID: int = None,
                  **kwargs):
         self.AgentFileID = AgentFileID
         self.Filename = Filename
@@ -22,6 +23,7 @@ class MythicRPCFileUpdateMessage:
         self.ReplaceContents = ReplaceContents
         self.Delete = Delete
         self.DeleteAfterFetch = DeleteAfterFetch
+        self.OperationID = OperationID
         for k, v in kwargs.items():
             logger.info(f"Unknown kwarg {k} - {v}")
 
@@ -32,7 +34,8 @@ class MythicRPCFileUpdateMessage:
             "comment": self.Comment,
             "append_contents": self.AppendContents,
             "delete": self.Delete,
-            "delete_after_fetch": self.DeleteAfterFetch
+            "delete_after_fetch": self.DeleteAfterFetch,
+            "operation_id": self.OperationID
         }
 
 


### PR DESCRIPTION
The documentation for FileSearch (and the error message you get back from it) suggest that it supports OperationID being used, however the client side code does not. 

This change was made and tested for FileSearch and was found to work.

It was noticed that the same logic also did not exist in FileUpdate (but is in FileCreate), so I have added them in there as well, however this has not yet been locally tested to make sure the server is handling OperationID properly for FileUpdate.