### PR TITLE
C2ProfileParameter Updates

### DIFF
--- a/mythic_container/C2ProfileBase.py
+++ b/mythic_container/C2ProfileBase.py
@@ -782,6 +782,8 @@ class C2ProfileParameter:
     Attributes:
         name (str): Name of the parameter for scripting and for when building payloads
         description (str): Informative description displayed when building a payload
+        display_name (str): Human-friendly label shown in the UI instead of the raw name
+        group_name (str): Optional section name the UI uses to cluster related parameters
         default_value (any): Default value to pre-populate
         randomize (bool): Should this value be randomized (requires format_string)
         format_string (str): A regex used for randomizing values if randomize is true
@@ -789,9 +791,12 @@ class C2ProfileParameter:
         required (bool): Is this parameter required to have a non-empty value or not
         verifier_regex (str): Regex used to verify that the user typed something appropriate
         choices (list[str]): Choices for ChooseOne parameter type
+        choices_display_names (dict[str, str]): Optional map of choice value to display label
         dictionary_choices (list[DictionaryChoice]): Configuration options for the Dictionary parameter type
         crypto_type (bool): Indicate if this value should be used to generate a crypto key or not
         ui_position (int): Optionally indicate an ordering to parameters instead of by name
+        form_schema (dict): Declarative schema describing the parameter's JSON shape so the Mythic UI
+            can render a Visual editor. See form_schema_spec.md for the wire format.
     Functions:
         to_json(self): return dictionary form of class
     """
@@ -810,6 +815,10 @@ class C2ProfileParameter:
             dictionary_choices: list[DictionaryChoice] = None,
             crypto_type: bool = False,
             ui_position: int = 0,
+            display_name: str = "",
+            group_name: str = "",
+            choices_display_names: dict = None,
+            form_schema: dict = None,
     ):
         self.name = name
         self.description = description
@@ -823,11 +832,17 @@ class C2ProfileParameter:
         self.crypto_type = crypto_type
         self.dictionary_choices = dictionary_choices
         self.ui_position = ui_position
+        self.display_name = display_name
+        self.group_name = group_name
+        self.choices_display_names = choices_display_names
+        self.form_schema = form_schema
 
     def to_json(self):
         return {
             "name": self.name,
             "description": self.description,
+            "display_name": self.display_name,
+            "group_name": self.group_name,
             "default_value": self.default_value,
             "randomize": self.randomize,
             "format_string": self.format_string,
@@ -836,9 +851,11 @@ class C2ProfileParameter:
             "verifier_regex": self.verifier_regex,
             "crypto_type": self.crypto_type,
             "choices": self.choices,
+            "choices_display_names": self.choices_display_names,
             "dictionary_choices": [x.to_json() for x in
                                    self.dictionary_choices] if self.dictionary_choices is not None else None,
-            "ui_position": self.ui_position
+            "ui_position": self.ui_position,
+            "form_schema": self.form_schema,
         }
 
     def __str__(self):


### PR DESCRIPTION
add display_name, group_name, choices_display_names, form_schema

Catches Python up on the parameter metadata extensions already in the Go library. Each field defaults to empty, is stored on the instance, and serializes via to_json so the c2 sync message carries it through to the Mythic server.

- display_name: human-friendly label for the UI.
- group_name: section heading to cluster related parameters.
- choices_display_names: per-choice label map for enum-style params.
- form_schema: declarative schema for the Visual editor. See form_schema_spec.md in the Mythic reference implementation.